### PR TITLE
Fix warnings when compiling with GCC and -Wcast-qual. This fixes #36

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -34,24 +34,24 @@ static char* rstrip(char* s)
 }
 
 /* Return pointer to first non-whitespace char in given string. */
-static char* lskip(const char* s)
+static char* lskip(char* s)
 {
     while (*s && isspace((unsigned char)(*s)))
         s++;
-    return (char*)s;
+    return s;
 }
 
 /* Return pointer to first char c or ';' comment in given string, or pointer to
    null at end of string if neither found. ';' must be prefixed by a whitespace
    character to register as a comment. */
-static char* find_char_or_comment(const char* s, char c)
+static char* find_char_or_comment(char* s, char c)
 {
     int was_whitespace = 0;
     while (*s && *s != c && !(was_whitespace && *s == ';')) {
         was_whitespace = isspace((unsigned char)(*s));
         s++;
     }
-    return (char*)s;
+    return s;
 }
 
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */


### PR DESCRIPTION
Actually, GCC and clang produce the same output before and after this commit, so no need to worry about a potential decrease in the generated code quality.

An alternative to discard the const qualifier between the parameter and the return would be to use strdup. But that would be overkill.