### PR TITLE
Take first of either : or = as the name / value delimiter

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -133,6 +133,12 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
             if (*end != '=') {
                 end = find_char_or_comment(start, ':');
             }
+            /* There may be a colon as well, use the first : or = found */
+            if (*(find_char_or_comment(start, ':')) == ':') {
+                if(*end != '=' || end > find_char_or_comment(start, ':')) {
+                    end = find_char_or_comment(start, ':');
+                }
+            }
             if (*end == '=' || *end == ':') {
                 *end = '\0';
                 name = rstrip(start);


### PR DESCRIPTION
I was looking for a C based ini parser to parse a file that I was already parsing with Python ConfigParser. Your library came in very handy!

My ini file uses colons for name/value delimiting, and I happen to have values that include an equal sign.

I found that an = in the value would override the : as a name/value delimiter. I made a change so that if both : and = appear in the ini entry, the first to occur is treated as the name/value delimiter.

Example:
somename: somevalue=morevalue

Before patch:
The name would parse as 'somename: somevalue'

After patch:
The name would parse as 'somename' and the value would parse as 'somevalue=morevalue'

I tried various combinations to check they work as expected after the patch:
somename=somevalue:morevalue
somename=somevalue=morevalue
somename:somevalue:morevalue

When I say 'work as expected', I mean as ConfigParser (python v2.7) behaves.

Thanks!