### PR TITLE
[INIReader] class now using constant reference as method arguments.

### DIFF
--- a/cpp/INIReader.cpp
+++ b/cpp/INIReader.cpp
@@ -23,7 +23,7 @@ int INIReader::ParseError() const
     return _error;
 }
 
-const string& INIReader::Get(const string& section, const string& name, const string& default_value) const
+string INIReader::Get(const string& section, const string& name, const string& default_value) const
 {
     string key = MakeKey(section, name);
     // Use _values.find() here instead of _values.at() to support pre C++11 compilers

--- a/cpp/INIReader.cpp
+++ b/cpp/INIReader.cpp
@@ -13,7 +13,7 @@
 
 using std::string;
 
-INIReader::INIReader(string filename)
+INIReader::INIReader(const string& filename)
 {
     _error = ini_parse(filename.c_str(), ValueHandler, this);
 }
@@ -23,14 +23,14 @@ int INIReader::ParseError() const
     return _error;
 }
 
-string INIReader::Get(string section, string name, string default_value) const
+const string& INIReader::Get(const string& section, const string& name, const string& default_value) const
 {
     string key = MakeKey(section, name);
     // Use _values.find() here instead of _values.at() to support pre C++11 compilers
     return _values.count(key) ? _values.find(key)->second : default_value;
 }
 
-long INIReader::GetInteger(string section, string name, long default_value) const
+long INIReader::GetInteger(const string& section, const string& name, long default_value) const
 {
     string valstr = Get(section, name, "");
     const char* value = valstr.c_str();
@@ -40,7 +40,7 @@ long INIReader::GetInteger(string section, string name, long default_value) cons
     return end > value ? n : default_value;
 }
 
-double INIReader::GetReal(string section, string name, double default_value) const
+double INIReader::GetReal(const string& section, const string& name, double default_value) const
 {
     string valstr = Get(section, name, "");
     const char* value = valstr.c_str();
@@ -49,7 +49,7 @@ double INIReader::GetReal(string section, string name, double default_value) con
     return end > value ? n : default_value;
 }
 
-bool INIReader::GetBoolean(string section, string name, bool default_value) const
+bool INIReader::GetBoolean(const string& section, const string& name, bool default_value) const
 {
     string valstr = Get(section, name, "");
     // Convert to lower case to make string comparisons case-insensitive
@@ -62,7 +62,7 @@ bool INIReader::GetBoolean(string section, string name, bool default_value) cons
         return default_value;
 }
 
-string INIReader::MakeKey(string section, string name)
+string INIReader::MakeKey(const string& section, const string& name)
 {
     string key = section + "=" + name;
     // Convert to lower case to make section/name lookups case-insensitive

--- a/cpp/INIReader.h
+++ b/cpp/INIReader.h
@@ -25,7 +25,7 @@ public:
     int ParseError() const;
 
     // Get a string value from INI file, returning default_value if not found.
-    const std::string& Get(const std::string& section, const std::string& name,
+    std::string Get(const std::string& section, const std::string& name,
                     const std::string& default_value) const;
 
     // Get an integer (long) value from INI file, returning default_value if

--- a/cpp/INIReader.h
+++ b/cpp/INIReader.h
@@ -18,34 +18,34 @@ class INIReader
 public:
     // Construct INIReader and parse given filename. See ini.h for more info
     // about the parsing.
-    INIReader(std::string filename);
+    INIReader(const std::string& filename);
 
     // Return the result of ini_parse(), i.e., 0 on success, line number of
     // first error on parse error, or -1 on file open error.
     int ParseError() const;
 
     // Get a string value from INI file, returning default_value if not found.
-    std::string Get(std::string section, std::string name,
-                    std::string default_value) const;
+    const std::string& Get(const std::string& section, const std::string& name,
+                    const std::string& default_value) const;
 
     // Get an integer (long) value from INI file, returning default_value if
     // not found or not a valid integer (decimal "1234", "-1234", or hex "0x4d2").
-    long GetInteger(std::string section, std::string name, long default_value) const;
+    long GetInteger(const std::string& section, const std::string& name, long default_value) const;
 
     // Get a real (floating point double) value from INI file, returning
     // default_value if not found or not a valid floating point value
     // according to strtod().
-    double GetReal(std::string section, std::string name, double default_value) const;
+    double GetReal(const std::string& section, const std::string& name, double default_value) const;
 
     // Get a boolean value from INI file, returning default_value if not found or if
     // not a valid true/false value. Valid true values are "true", "yes", "on", "1",
     // and valid false values are "false", "no", "off", "0" (not case sensitive).
-    bool GetBoolean(std::string section, std::string name, bool default_value) const;
+    bool GetBoolean(const std::string& section, const std::string& name, bool default_value) const;
 
 private:
     int _error;
     std::map<std::string, std::string> _values;
-    static std::string MakeKey(std::string section, std::string name);
+    static std::string MakeKey(const std::string& section, const std::string& name);
     static int ValueHandler(void* user, const char* section, const char* name,
                             const char* value);
 };


### PR DESCRIPTION
Hello.

I propose to change argument types from direct type to constant reference so it will be good from performance side as string do not copy at method call.
Get method also can return constant reference so no temporary string will not be provided, it copy already to string that expected to take data from Get method.

Thank you.

P.S.
By the way, if you interesting about other change that can be provide for this class (most expected that compiler support C++ 11) I save my view at [separate branch](https://github.com/TheVice/inih/tree/vicemaster) at repository fork.