### PR TITLE
Add ini_parse_unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Download a release, browse the source, or read about [how to use inih in a DRY s
   * **Stop on first error:** By default, inih keeps parsing the rest of the file after an error. To stop parsing on the first error, add `-DINI_STOP_ON_FIRST_ERROR=1`.
   * **Maximum line length:** The default maximum line length is 200 bytes. To override this, add something like `-DINI_MAX_LINE=1000`.
   * **Report line numbers:** By default, the `ini_handler` callback doesn't receive the line number as a parameter. If you need that, add `-DINI_HANDLER_LINENO=1`.
+  * **Unicode paths:** By default, the `ini_parse_unicode` function is compiled.  If your environment does not support the wchar_t type or the \_wfopen function, add `-DINI_ENABLE_UNICODE=0`.
 
 
 ## Simple example in C ##

--- a/ini.c
+++ b/ini.c
@@ -206,6 +206,22 @@ int ini_parse(const char* filename, ini_handler handler, void* user)
     return error;
 }
 
+/* See documentation in header file. */
+#if INI_ENABLE_UNICODE
+int ini_parse_unicode(const wchar_t* filename, ini_handler handler, void* user)
+{
+	FILE* file;
+	int error;
+
+	file = _wfopen(filename, L"r");
+	if (!file)
+		return -1;
+	error = ini_parse_file(file, handler, user);
+	fclose(file);
+	return error;
+}
+#endif
+
 /* An ini_reader function to read the next line from a string buffer. This
    is the fgets() equivalent used by ini_parse_string(). */
 static char* ini_reader_string(char* str, int num, void* stream) {

--- a/ini.h
+++ b/ini.h
@@ -22,6 +22,11 @@ extern "C" {
 #define INI_HANDLER_LINENO 0
 #endif
 
+/* Nonzero to compile ini_parse_unicode, zero to skip */
+#ifndef INI_ENABLE_UNICODE
+#define INI_ENABLE_UNICODE 1
+#endif
+
 /* Typedef for prototype of handler function. */
 #if INI_HANDLER_LINENO
 typedef int (*ini_handler)(void* user, const char* section,
@@ -49,6 +54,26 @@ typedef char* (*ini_reader)(char* str, int num, void* stream);
    error (only when INI_USE_STACK is zero).
 */
 int ini_parse(const char* filename, ini_handler handler, void* user);
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's configparser.
+
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+   
+   This version of the function loads an INI-style file from a Unicode path;
+   however the callback still uses ANSI style strings.
+*/
+#if INI_ENABLE_UNICODE
+int ini_parse_unicode(const wchar_t* filename, ini_handler handler, void* user);
+#endif
 
 /* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
    close the file when it's finished -- the caller must do that. */


### PR DESCRIPTION
Adds a version of the ini_parse function that loads a file from a Unicode path.
Since not all embedded platforms might support Unicode, ini.h has added an option INI_ENABLE_UNICODE which can be set to 0 to disable compiling the ini_parse_unicode function.