### PR TITLE
Add support for allowing name without value

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -192,9 +192,23 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                 if (!HANDLER(user, section, name, value) && !error)
                     error = lineno;
             }
-            else if (!error) {
+            else {
                 /* No '=' or ':' found on name[=:]value line */
-                error = lineno;
+#if INI_ALLOW_NO_VALUE
+                name = start;
+                value = NULL;
+                *prev_name = '\0';
+                if (
+#if INI_ALLOW_MULTILINE
+                    /* Non-blank line with leading whitespace,
+                       but no previous name for continuation. */
+                    start > line ||
+#endif
+                    !HANDLER(user, section, name, value))
+#endif
+                if (!error) {
+                    error = lineno;
+                }
             }
         }
 

--- a/ini.h
+++ b/ini.h
@@ -78,6 +78,12 @@ int ini_parse_string(const char* string, ini_handler handler, void* user);
 #define INI_ALLOW_BOM 1
 #endif
 
+/* Nonzero to allow name without value, namely line contains no delimiter
+   [=:]. If allowed, value will be set to NULL for name without a value. */
+#ifndef INI_ALLOW_NO_VALUE
+#define INI_ALLOW_NO_VALUE 0
+#endif
+
 /* Chars that begin a start-of-line comment. Per Python configparser, allow
    both ; and # comments at the start of a line by default. */
 #ifndef INI_START_COMMENT_PREFIXES

--- a/tests/bad_comment.ini
+++ b/tests/bad_comment.ini
@@ -1,1 +1,1 @@
-This is an error
+This is a name with no value

--- a/tests/baseline_allow_no_value.txt
+++ b/tests/baseline_allow_no_value.txt
@@ -1,0 +1,54 @@
+no_file.ini: e=-1 user=0
+... [section1]
+... one=This is a test;
+... two=1234;
+... [ section 2 ]
+... happy=4;
+... sad=;
+... [comment_test]
+... test1=1;2;3;
+... test2=2;3;4;this won't be a comment, needs whitespace before ';';
+... test;3=345;
+... test4=4#5#6;
+... test7=;
+... test8=; not a comment, needs whitespace before ';';
+... [colon_tests]
+... Content-Type=text/html;
+... foo=bar;
+... adams=42;
+... funny1=with = equals;
+... funny2=with : colons;
+... funny3=two = equals;
+... funny4=two : colons;
+normal.ini: e=0 user=101
+... [section1]
+... name1=value1;
+... name2=value2;
+bad_section.ini: e=3 user=102
+... This is a name with no value=(null);
+bad_comment.ini: e=0 user=103
+... [section]
+... a=b;
+... user=parse_error;
+... c=d;
+user_error.ini: e=3 user=104
+... [section1]
+... single1=abc;
+... multi=this is a;
+... multi=multi-line value;
+... single2=xyz;
+... [section2]
+... multi=a;
+... multi=b;
+... multi=c;
+... [section3]
+... single=ghi;
+... multi=the quick;
+... multi=brown fox;
+... name=bob smith;
+multi_line.ini: e=0 user=105
+bad_multi.ini: e=1 user=105
+... [bom_section]
+... bom_name=bom_value;
+... key“=value“;
+bom.ini: e=0 user=107

--- a/tests/unittest.bat
+++ b/tests/unittest.bat
@@ -2,6 +2,7 @@
 @call tcc ..\ini.c -I..\ -DINI_MAX_LINE=20 -run unittest.c > baseline_multi_max_line.txt
 @call tcc ..\ini.c -I..\ -DINI_ALLOW_MULTILINE=0 -run unittest.c > baseline_single.txt
 @call tcc ..\ini.c -I..\ -DINI_ALLOW_INLINE_COMMENTS=0 -run unittest.c > baseline_disallow_inline_comments.txt
+@call tcc ..\ini.c -I..\ -DINI_ALLOW_NO_VALUE=1 -run unittest.c > baseline_allow_no_value.txt
 @call tcc ..\ini.c -I..\ -DINI_STOP_ON_FIRST_ERROR=1 -run unittest.c > baseline_stop_on_first_error.txt
 @call tcc ..\ini.c -I..\ -DINI_HANDLER_LINENO=1 -run unittest.c > baseline_handler_lineno.txt
 @call tcc ..\ini.c -I..\ -DINI_USE_STACK=0 -run unittest.c > baseline_heap.txt

--- a/tests/unittest.sh
+++ b/tests/unittest.sh
@@ -16,6 +16,10 @@ gcc ../ini.c -DINI_ALLOW_INLINE_COMMENTS=0 unittest.c -o unittest_disallow_inlin
 ./unittest_disallow_inline_comments > baseline_disallow_inline_comments.txt
 rm -f unittest_disallow_inline_comments
 
+gcc ../ini.c -DINI_ALLOW_NO_VALUE=1 unittest.c -o unittest_allow_no_value
+./unittest_allow_no_value > baseline_allow_no_value.txt
+rm -f unittest_allow_no_value
+
 gcc ../ini.c -DINI_STOP_ON_FIRST_ERROR=1 unittest.c -o unittest_stop_on_first_error
 ./unittest_stop_on_first_error > baseline_stop_on_first_error.txt
 rm -f unittest_stop_on_first_error


### PR DESCRIPTION
Per Python configparser's [init option](https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour) `allow_no_value`, which makes the following a legitimate config:
```ini
a name without value
```
with name `"a name without value"` and value `NULL`.