### PR TITLE
Avoid cppcheck free() error

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -87,7 +87,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
     char* line;
     int max_line = INI_INITIAL_ALLOC;
 #endif
-#if INI_ALLOW_REALLOC
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
     char* new_line;
     int offset;
 #endif
@@ -116,7 +116,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
 
     /* Scan through stream line by line */
     while (reader(line, max_line, stream) != NULL) {
-#if INI_ALLOW_REALLOC
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
         offset = strlen(line);
         while (offset == max_line - 1 && line[offset - 1] != '\n') {
             max_line *= 2;


### PR DESCRIPTION
This avoids this error and warning in cppcheck:
```
[ini.c:92]: (style) The scope of the variable 'offset' can be reduced.
[ini.c:127]: (error) Deallocation of an auto-variable results in undefined behaviour.
```

We don't need to free 'line' if we're using the stack. This also avoids problems if the user misconfigures their inih options by setting INI_ALLOW_REALLOC while using the stack, which as ini.h says "Only applies if INI_USE_STACK is zero."