### PR TITLE
Add INIReader::GetString to get nicer default_value behavior

### DIFF
--- a/cpp/INIReader.cpp
+++ b/cpp/INIReader.cpp
@@ -30,6 +30,12 @@ string INIReader::Get(const string& section, const string& name, const string& d
     return _values.count(key) ? _values.find(key)->second : default_value;
 }
 
+string INIReader::GetString(const string& section, const string& name, const string& default_value) const
+{
+    const string str = Get(section, name, "");
+    return str.empty() ? default_value : str;
+}
+
 long INIReader::GetInteger(const string& section, const string& name, long default_value) const
 {
     string valstr = Get(section, name, "");

--- a/cpp/INIReader.h
+++ b/cpp/INIReader.h
@@ -27,6 +27,10 @@ public:
     // Get a string value from INI file, returning default_value if not found.
     std::string Get(const std::string& section, const std::string& name,
                     const std::string& default_value) const;
+    
+    // Get a string value from INI file, returning default_value if not found or empty.
+    std::string GetString(const std::string& section, const std::string& name,
+                    const std::string& default_value) const;
 
     // Get an integer (long) value from INI file, returning default_value if
     // not found or not a valid integer (decimal "1234", "-1234", or hex "0x4d2").

--- a/cpp/INIReader.h
+++ b/cpp/INIReader.h
@@ -28,7 +28,8 @@ public:
     std::string Get(const std::string& section, const std::string& name,
                     const std::string& default_value) const;
     
-    // Get a string value from INI file, returning default_value if not found or empty.
+    // Get a string value from INI file, returning default_value if not found,
+    // empty, or contains only whitespace.
     std::string GetString(const std::string& section, const std::string& name,
                     const std::string& default_value) const;
 


### PR DESCRIPTION
Same as `INIReader::Get`, but returns `default_value` if the value is an empty string, which provides functionality similar to `GetInteger` and the others.

I'm not sure about the function name (implies that `Get` is something else?), but I definitely don't want to change the behavior of `Get` and I also think this functionality is really needed. `GetString` is the best name I could come up with that isn't overly convoluted (e.g. I ruled out `GetButIfValueIsEmptyStringThenReturnDefaultValueInstead`) and I don't think it'll cause anyone trouble.