### PR TITLE
Allow handler to receive section number

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can control various aspects of inih using preprocessor defines:
 
   * **Stop on first error:** By default, inih keeps parsing the rest of the file after an error. To stop parsing on the first error, add `-DINI_STOP_ON_FIRST_ERROR=1`.
   * **Report line numbers:** By default, the `ini_handler` callback doesn't receive the line number as a parameter. If you need that, add `-DINI_HANDLER_LINENO=1`.
+  * **Report section number:** By default, the `ini_handler` callback doesn' receive the section number as a parameter. If you need that add `-DINI_HANDLER_SECTIONNO=1`, INI_HANDLER_LINENO and INI_HANDLER_SECIONNO are mutualy exclusives and INI_HANDLER_LINENO is checked first.
 
 ### Memory options ###
 

--- a/ini.c
+++ b/ini.c
@@ -100,6 +100,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
     char* value;
     int lineno = 0;
     int error = 0;
+    int sectionno = 0;
 
 #if !INI_USE_STACK
     line = (char*)malloc(INI_INITIAL_ALLOC);
@@ -110,6 +111,8 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
 
 #if INI_HANDLER_LINENO
 #define HANDLER(u, s, n, v) handler(u, s, n, v, lineno)
+#elif INI_HANDLER_SECTIONNO
+#define HANDLER(u, s, n, v) handler(u, s, n, v, sectionno)
 #else
 #define HANDLER(u, s, n, v) handler(u, s, n, v)
 #endif
@@ -166,6 +169,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                 *end = '\0';
                 strncpy0(section, start + 1, sizeof(section));
                 *prev_name = '\0';
+                sectionno++;
             }
             else if (!error) {
                 /* No ']' found on section line */

--- a/ini.h
+++ b/ini.h
@@ -27,6 +27,10 @@ extern "C" {
 typedef int (*ini_handler)(void* user, const char* section,
                            const char* name, const char* value,
                            int lineno);
+#elif INI_HANDLER_SECTIONNO
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value,
+                           int sectionno);
 #else
 typedef int (*ini_handler)(void* user, const char* section,
                            const char* name, const char* value);


### PR DESCRIPTION
Hi, 
This change allow to distingish multiples sections with same name and so build an array.

# conf.ini
[sectionA]
param=value1

[sectionA]
param=value2

# handler.c
typdef struct
{
    int a;
} Element;

typedef struct 
{
    Element* elements;    
    int count;
} Array;

int  _inihandler(void* user, const char* section, const char* name, const char* value,int sectionno)
{

    Array* array;
    Element* element;

    array = (Array*) user;

    if( sectiono != array->count )
    {
        array->elements = realloc( array->elements, sizeof(Element) * sectionno );
        element = array->elements[array->count];
        array->count++;
    }
}