### PR TITLE
2019 07 add copyright and spdx

### DIFF
--- a/cpp/INIReader.cpp
+++ b/cpp/INIReader.cpp
@@ -1,5 +1,7 @@
 // Read an INI file into easy-to-access name/value pairs.
 
+// SPDX-License-Identifier: BSD-3-Clause
+
 // Copyright (C) 2009-2019, Ben Hoyt
 
 // inih and INIReader are released under the New BSD license (see LICENSE.txt).

--- a/cpp/INIReader.cpp
+++ b/cpp/INIReader.cpp
@@ -1,5 +1,7 @@
 // Read an INI file into easy-to-access name/value pairs.
 
+// Copyright (C) 2009-2019, Ben Hoyt
+
 // inih and INIReader are released under the New BSD license (see LICENSE.txt).
 // Go to the project home page for more info:
 //

--- a/cpp/INIReader.h
+++ b/cpp/INIReader.h
@@ -1,5 +1,7 @@
 // Read an INI file into easy-to-access name/value pairs.
 
+// SPDX-License-Identifier: BSD-3-Clause
+
 // Copyright (C) 2009-2019, Ben Hoyt
 
 // inih and INIReader are released under the New BSD license (see LICENSE.txt).

--- a/cpp/INIReader.h
+++ b/cpp/INIReader.h
@@ -1,5 +1,7 @@
 // Read an INI file into easy-to-access name/value pairs.
 
+// Copyright (C) 2009-2019, Ben Hoyt
+
 // inih and INIReader are released under the New BSD license (see LICENSE.txt).
 // Go to the project home page for more info:
 //

--- a/ini.c
+++ b/ini.c
@@ -1,5 +1,7 @@
 /* inih -- simple .INI file parser
 
+SPDX-License-Identifier: BSD-3-Clause
+
 Copyright (C) 2009-2019, Ben Hoyt
 
 inih is released under the New BSD license (see LICENSE.txt). Go to the project

--- a/ini.c
+++ b/ini.c
@@ -1,5 +1,7 @@
 /* inih -- simple .INI file parser
 
+Copyright (C) 2009-2019, Ben Hoyt
+
 inih is released under the New BSD license (see LICENSE.txt). Go to the project
 home page for more info:
 

--- a/ini.h
+++ b/ini.h
@@ -1,5 +1,7 @@
 /* inih -- simple .INI file parser
 
+SPDX-License-Identifier: BSD-3-Clause
+
 Copyright (C) 2009-2019, Ben Hoyt
 
 inih is released under the New BSD license (see LICENSE.txt). Go to the project

--- a/ini.h
+++ b/ini.h
@@ -1,5 +1,7 @@
 /* inih -- simple .INI file parser
 
+Copyright (C) 2009-2019, Ben Hoyt
+
 inih is released under the New BSD license (see LICENSE.txt). Go to the project
 home page for more info:
 


### PR DESCRIPTION
Afaiui inih is not shipped as a shared library but is designed for copying the relevant files to inih-using project's sources.  Especially for this use-case it is very helpful to have proper attribution and clear, accessible information about the applicable license terms _in each file_.

This merge request adds
a) a copyright statement and
b) an SPDX id  https://spdx.org/ids to have in-file license information.

Thanks for considering!
