### PR TITLE
Fix possible int overflow in reader cb

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -86,14 +86,14 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
     /* Uses a fair bit of stack (use heap instead if you need to) */
 #if INI_USE_STACK
     char line[INI_MAX_LINE];
-    int max_line = INI_MAX_LINE;
+    size_t max_line = INI_MAX_LINE;
 #else
     char* line;
-    int max_line = INI_INITIAL_ALLOC;
+    size_t max_line = INI_INITIAL_ALLOC;
 #endif
 #if INI_ALLOW_REALLOC && !INI_USE_STACK
     char* new_line;
-    int offset;
+    size_t offset;
 #endif
     char section[MAX_SECTION] = "";
     char prev_name[MAX_NAME] = "";

--- a/ini.c
+++ b/ini.c
@@ -86,7 +86,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
     /* Uses a fair bit of stack (use heap instead if you need to) */
 #if INI_USE_STACK
     char line[INI_MAX_LINE];
-    size_t max_line = INI_MAX_LINE;
+    int max_line = INI_MAX_LINE;
 #else
     char* line;
     size_t max_line = INI_INITIAL_ALLOC;

--- a/ini.c
+++ b/ini.c
@@ -119,7 +119,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
 #endif
 
     /* Scan through stream line by line */
-    while (reader(line, max_line, stream) != NULL) {
+    while (reader(line, (int)max_line, stream) != NULL) {
 #if INI_ALLOW_REALLOC && !INI_USE_STACK
         offset = strlen(line);
         while (offset == max_line - 1 && line[offset - 1] != '\n') {
@@ -132,7 +132,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                 return -2;
             }
             line = new_line;
-            if (reader(line + offset, max_line - offset, stream) == NULL)
+            if (reader(line + offset, (int)(max_line - offset), stream) == NULL)
                 break;
             if (max_line >= INI_MAX_LINE)
                 break;

--- a/ini.h
+++ b/ini.h
@@ -37,7 +37,7 @@ typedef int (*ini_handler)(void* user, const char* section,
 #endif
 
 /* Typedef for prototype of fgets-style reader function. */
-typedef char* (*ini_reader)(char* str, size_t num, void* stream);
+typedef char* (*ini_reader)(char* str, int num, void* stream);
 
 /* Parse given INI-style file. May have [section]s, name=value pairs
    (whitespace stripped), and comments starting with ';' (semicolon). Section

--- a/ini.h
+++ b/ini.h
@@ -37,7 +37,7 @@ typedef int (*ini_handler)(void* user, const char* section,
 #endif
 
 /* Typedef for prototype of fgets-style reader function. */
-typedef char* (*ini_reader)(char* str, int num, void* stream);
+typedef char* (*ini_reader)(char* str, size_t num, void* stream);
 
 /* Parse given INI-style file. May have [section]s, name=value pairs
    (whitespace stripped), and comments starting with ';' (semicolon). Section


### PR DESCRIPTION
This fixes compile failures with the strict compiler flags, please see below.

It's to see, that `(ini_reader)fgets` is actually used as reader, which actually uses int. Still, it is done as an explicit cast. The surrounding errors reported by the compiler are about `strlen` result assigned to an int var, and int var passed to realloc. An enhancement to this might be to additionally write a wrapper around fgets, which would use `size_t` in the signature. 

Another way to solve this would be to keep ints, and do explicit casts. IMO size_t is a better solution, for both type safety and security.

Finally, i'm not sure how bad it is to break the existing API, but from the usability perspective this should be fixed one or another way.

Thanks.

```
inih/ini.c: In function ‘ini_parse_stream’:
inih/ini.c:124:18: error: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Werror=conversion]
         offset = strlen(line);
                  ^~~~~~
inih/ini.c:129:38: error: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Werror=sign-conversion]
             new_line = realloc(line, max_line);
                                      ^~~~~~~~
inih/ini.c:139:20: error: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Werror=sign-conversion]
             offset += strlen(line + offset);
                    ^~
inih/ini.c:139:23: error: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Werror=conversion]
             offset += strlen(line + offset);
                       ^~~~~~
```