### PR TITLE
Switch from strncpy to memcpy in strcpy0 function

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -74,7 +74,7 @@ static char* find_chars_or_comment(const char* s, const char* chars)
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */
 static char* strncpy0(char* dest, const char* src, size_t size)
 {
-    strncpy(dest, src, size - 1);
+    memcpy(dest, src, size - 1);
     dest[size - 1] = '\0';
     return dest;
 }


### PR DESCRIPTION
This pull request fixes a stringop-truncation warning.
ini.c:78:5: warning: ‘strncpy’ output may be truncated copying 49 bytes from a string of length 199 [-Wstringop-truncation]