### PR TITLE
add meson for system install

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,42 @@
+project('inih',
+    ['c','cpp'],
+    meson_version : '>= 0.46.0',
+    default_options : ['default_library=both'],
+    license : 'BSD-3-Clause',
+    version : '47'
+)
+
+pkg = import('pkgconfig')
+
+#### inih ####
+install_headers('ini.h')
+
+lib_inih = library('inih',
+    ['ini.c', 'ini.h'],
+    install : true,
+    version : meson.project_version(),
+    soversion : '1'
+)
+
+pkg.generate(lib_inih,
+    name : 'inih',
+    description : 'simple .INI file parser',
+    version : meson.project_version()
+)
+
+#### INIReader ####
+install_headers('cpp/INIReader.h')
+
+lib_INIReader = library('INIReader',
+    ['cpp/INIReader.cpp', 'cpp/INIReader.h'],
+    dependencies : declare_dependency(link_with : lib_inih),
+    install : true,
+    version : meson.project_version(),
+    soversion : '1'
+)
+
+pkg.generate(lib_INIReader,
+    name : 'INIReader',
+    description : 'simple .INI file parser for C++',
+    version : meson.project_version()
+)


### PR DESCRIPTION
I don't know if you are interested considering #59, but I wired up meson support anyway. This is purely optional for users, but a nice feature for distros that want to ship your parser.
The specific reason for this is Feral's gamemode, which ship its own (old) version of inih but rather should use a system installation which is easy to link against.

Installing via meson adds `ini.h` to the include path, adds a shared library `libinih.so` which programs can dynamically link against and also adds a pkg-config entry, so programs can find it.
The nice thing about meson is that you don't have to care about any paths, just change the project version for a new release, and in case there is a breaking API change bump the `soversion`.
In case you don't want to change the build file for every release, I can also remove that feature.