### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ Some differences between inih and Python's [ConfigParser](http://docs.python.org
 * If you want to use inih for programs which may be shipped in a distro, consider linking against the shared library. Meson adds entries for pkg-config (`inih` and `INIReader`).
 * In case you use inih as a subproject, you can use the `inih_dep` and `INIReader_dep` dependency variables.
 
+## Building from vcpkg ##
+
+You can build and install inih using [vcpkg](https://github.com/microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install inih
+
+The inih port in vcpkg is kept up to date by microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Related links ##
 
 * [Conan package for inih](https://github.com/mohamedghita/conan-inih) (Conan is a C/C++ package manager)


### PR DESCRIPTION
Inih is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build Inih, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for Inih and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.