### PR TITLE
Add options for Meson

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,13 @@ Some differences between inih and Python's [ConfigParser](http://docs.python.org
 
 ## Meson notes ##
 
-* The `meson.build` file is intended to build libraries which can be installed on a system. This is not required to use or compile inih.
-* If you want to use inih for programs which may be shipped in a distro, consider linking against the shared library. Meson adds entries for pkg-config (`inih` and `INIReader`).
+* The `meson.build` file is not required to use or compile inih, its main purpose is for distributions.
+* By default Meson only creates a static library for inih, but Meson can be used to configure this behavior:
+* with `-Ddefault_library=shared` a shared library is build.
+* with `-Ddistro_install=true` the library will be installed with the header and a pkg-config entry, you may want to set `-Ddefault_library=shared` when using this.
+* with `-Dwith_INIReader` you can build (and install if selected) the C++ library.
+* all compile-time options are implemented in Meson as well, you can take a look at [meson_options.txt](https://github.com/benhoyt/inih/blob/master/meson_options.txt) for their definition. These won't work if `distro_install` is set to `true`.
+* If you want to use inih for programs which may be shipped in a distro, consider linking against the shared libraries. The pkg-config entries are `inih` and `INIReader`.
 * In case you use inih as a subproject, you can use the `inih_dep` and `INIReader_dep` dependency variables.
 
 ## Building from vcpkg ##

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ You can control various aspects of inih using preprocessor defines:
 
   * **Stack vs heap:** By default, inih creates a fixed-sized line buffer on the stack. To allocate on the heap using `malloc` instead, specify `-DINI_USE_STACK=0`.
   * **Maximum line length:** The default maximum line length (for stack or heap) is 200 bytes. To override this, add something like `-DINI_MAX_LINE=1000`. Note that `INI_MAX_LINE` must be 3 more than the longest line (due to `\r`, `\n`, and the NUL).
-  * **Allow realloc:** By default when using the heap (`-DINI_USE_STACK=0`), inih allocates a fixed-sized buffer of `INI_INITIAL_ALLOC` bytes. To allow this to grow to `INI_MAX_LINE` bytes, doubling if needed, set `-DINI_ALLOW_REALLOC=1`.
   * **Initial malloc size:** `INI_INITIAL_ALLOC` specifies the initial malloc size when using the heap. It defaults to 200 bytes.
+  * **Allow realloc:** By default when using the heap (`-DINI_USE_STACK=0`), inih allocates a fixed-sized buffer of `INI_INITIAL_ALLOC` bytes. To allow this to grow to `INI_MAX_LINE` bytes, doubling if needed, set `-DINI_ALLOW_REALLOC=1`.
 
 ## Simple example in C ##
 

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('inih',
     ['c','cpp'],
     default_options : ['default_library=static'],
     license : 'BSD-3-Clause',
-    version : '48'
+    version : '49'
 )
 
 #### options ####

--- a/meson.build
+++ b/meson.build
@@ -1,31 +1,84 @@
 project('inih',
     ['c','cpp'],
-    meson_version : '>= 0.46.0',
-    default_options : ['default_library=both'],
+    default_options : ['default_library=static'],
     license : 'BSD-3-Clause',
     version : '48'
 )
 
-pkg = import('pkgconfig')
+#### options ####
+
+arg_static = []
+distro_install = get_option('distro_install')
+
+if distro_install
+    pkg = import('pkgconfig')
+else
+    if not get_option('multi-line_entries')
+        arg_static += ['-DINI_ALLOW_MULTILINE=0']
+    endif
+    if not get_option('utf-8_bom')
+        arg_static += ['-DINI_ALLOW_BOM=0']
+    endif
+    if not get_option('inline_comments')
+        arg_static += ['-DINI_ALLOW_INLINE_COMMENTS=0']
+    endif
+    inline_comment_prefix = get_option('inline_comment_prefix')
+    if inline_comment_prefix != ';'
+        arg_static += ['-DINI_INLINE_COMMENT_PREFIXES="' + inline_comment_prefix + '"']
+    endif
+    sol_comment_prefix = get_option('start-of-line_comment_prefix')
+    if sol_comment_prefix != ';#'
+        arg_static += ['-DINI_START_COMMENT_PREFIXES="' + start-of-line_comment_prefix + '"']
+    endif
+    if get_option('allow_no_value')
+        arg_static += ['-DINI_ALLOW_NO_VALUE=1']
+    endif
+    if get_option('stop_on_first_error')
+        arg_static += ['-DINI_STOP_ON_FIRST_ERROR=1']
+    endif
+    if get_option('report_line_numbers')
+        arg_static += ['-DINI_HANDLER_LINENO=1']
+    endif
+    if get_option('call_handler_on_new_section')
+        arg_static += ['-DINI_CALL_HANDLER_ON_NEW_SECTION=1']
+    endif
+    if get_option('use_heap')
+        arg_static += ['-DINI_USE_STACK=0']
+    endif
+    max_line_length = get_option('max_line_length')
+    if max_line_length != 200
+        arg_static += ['-DINI_MAX_LINE=' + str(max_line_length)]
+    endif
+    initial_malloc_size = get_option('initial_malloc_size')
+    if initial_malloc_size != 200
+        arg_static += ['-DINI_INITIAL_ALLOC=' + str(initial_malloc_size)]
+    endif
+    if get_option('allow_realloc')
+        arg_static += ['-DINI_ALLOW_REALLOC=1']
+    endif
+endif
 
 #### inih ####
-install_headers('ini.h')
-
 inc_inih = include_directories('.')
 
 lib_inih = library('inih',
     ['ini.c'],
     include_directories : inc_inih,
-    install : true,
+    c_args : arg_static,
+    install : distro_install,
     version : meson.project_version(),
     soversion : '0'
 )
 
-pkg.generate(lib_inih,
-    name : 'inih',
-    description : 'simple .INI file parser',
-    version : meson.project_version()
-)
+if distro_install
+    install_headers('ini.h')
+
+    pkg.generate(lib_inih,
+        name : 'inih',
+        description : 'simple .INI file parser',
+        version : meson.project_version()
+    )
+endif
 
 inih_dep = declare_dependency(
     link_with : lib_inih,
@@ -33,26 +86,30 @@ inih_dep = declare_dependency(
 )
 
 #### INIReader ####
-install_headers('cpp/INIReader.h')
+if get_option('with_INIReader')
+    inc_INIReader = include_directories('cpp')
 
-inc_INIReader = include_directories('cpp')
+    lib_INIReader = library('INIReader',
+        ['cpp/INIReader.cpp'],
+        include_directories : inc_INIReader,
+        dependencies : inih_dep,
+        install : distro_install,
+        version : meson.project_version(),
+        soversion : '0'
+    )
 
-lib_INIReader = library('INIReader',
-    ['cpp/INIReader.cpp'],
-    include_directories : inc_INIReader,
-    dependencies : inih_dep,
-    install : true,
-    version : meson.project_version(),
-    soversion : '0'
-)
+    if distro_install
+        install_headers('cpp/INIReader.h')
 
-pkg.generate(lib_INIReader,
-    name : 'INIReader',
-    description : 'simple .INI file parser for C++',
-    version : meson.project_version()
-)
+        pkg.generate(lib_INIReader,
+            name : 'INIReader',
+            description : 'simple .INI file parser for C++',
+            version : meson.project_version()
+        )
+    endif
 
-INIReader_dep = declare_dependency(
-    link_with : lib_INIReader,
-    include_directories : inc_INIReader
-)
+    INIReader_dep = declare_dependency(
+        link_with : lib_INIReader,
+        include_directories : inc_INIReader
+    )
+endif

--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,6 @@ pkg.generate(lib_INIReader,
 )
 
 INIReader_dep = declare_dependency(
-    link_with : lib_inih,
+    link_with : lib_INIReader,
     include_directories : inc_INIReader
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,75 @@
+option('distro_install',
+  type : 'boolean',
+  value : false,
+  description : 'install shared libs, headers and pkg-config entries'
+)
+option('with_INIReader',
+  type : 'boolean',
+  value : false,
+  description : 'compile and (if selected) install INIReader'
+)
+option('multi-line_entries',
+  type : 'boolean',
+  value : true,
+  description : 'support for multi-line entries in the style of Python\'s ConfigParser'
+)
+option('utf-8_bom',
+  type : 'boolean',
+  value : true,
+  description : 'allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of INI files'
+)
+option('inline_comments',
+  type : 'boolean',
+  value : true,
+  description : 'allow inline comments with the comment prefix character'
+)
+option('inline_comment_prefix',
+  type : 'string',
+  value : ';',
+  description : 'character(s) to start an inline comment (if enabled)'
+)
+option('start-of-line_comment_prefix',
+  type : 'string',
+  value : ';#',
+  description : 'character(s) to start a comment at the beginning of a line'
+)
+option('allow_no_value',
+  type : 'boolean',
+  value : false,
+  description : 'allow name with no value'
+)
+option('stop_on_first_error',
+  type : 'boolean',
+  value : false,
+  description : 'stop parsing after an error'
+)
+option('report_line_numbers',
+  type : 'boolean',
+  value : false,
+  description : 'report line number on ini_handler callback'
+)
+option('call_handler_on_new_section',
+  type : 'boolean',
+  value : false,
+  description : 'call the handler each time a new section is encountered'
+)
+option('use_heap',
+  type : 'boolean',
+  value : false,
+  description : 'allocate memory on the heap using malloc instead using a fixed-sized line buffer on the stack'
+)
+option('max_line_length',
+  type : 'integer',
+  value : 200,
+  description : 'maximum line length in bytes'
+)
+option('initial_malloc_size',
+  type : 'integer',
+  value : 200,
+  description : 'initial malloc size in bytes (when using the heap)'
+)
+option('allow_realloc',
+  type : 'boolean',
+  value : false,
+  description : 'allow initial malloc size to grow to max line length (when using the heap)'
+)


### PR DESCRIPTION
With this PR I want to add the possibility to _either_ install inih as a shared library _or_ to just build it as a static library. Installing it by default causes some minor inconveniences for some downstream users, so making it optional seems a good idea. I also sneaked in two minor commits.

WiP since I currently only implemented the installation option.

Is it okay to mark this as r49 once implemented? Would get it faster to downstream users.

/cc @kakra, ref FeralInteractive/gamemode#222.