### PR TITLE
Meson: fix the integer conversions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,11 +45,11 @@ else
     endif
     max_line_length = get_option('max_line_length')
     if max_line_length != 200
-        arg_static += ['-DINI_MAX_LINE=' + str(max_line_length)]
+        arg_static += ['-DINI_MAX_LINE=' + max_line_length.to_string()]
     endif
     initial_malloc_size = get_option('initial_malloc_size')
     if initial_malloc_size != 200
-        arg_static += ['-DINI_INITIAL_ALLOC=' + str(initial_malloc_size)]
+        arg_static += ['-DINI_INITIAL_ALLOC=' + initial_malloc_size.to_string()]
     endif
     if get_option('allow_realloc')
         arg_static += ['-DINI_ALLOW_REALLOC=1']


### PR DESCRIPTION
Meson doesn't have a `str` function, so it's not possible to change the integer options.
`subprojects/inih/meson.build:50:8: ERROR: Unknown function "str".`