### PR TITLE
allow ']' in section name

### DIFF
--- a/tests/baseline_heap_string.txt
+++ b/tests/baseline_heap_string.txt
@@ -19,3 +19,13 @@ long continued: e=0 user=104
 ... a=1;
 ... c=3;
 error: e=3 user=105
+... [sec[tio]n]
+... a=1;
+... b=2;
+... c=3;
+odd section: e=0 user=106
+... [section]
+... a=1;
+... b=2;
+... c=3;
+odd section with comment: e=0 user=107

--- a/tests/baseline_string.txt
+++ b/tests/baseline_string.txt
@@ -19,3 +19,13 @@ long continued: e=0 user=104
 ... a=1;
 ... c=3;
 error: e=3 user=105
+... [sec[tio]n]
+... a=1;
+... b=2;
+... c=3;
+odd section: e=0 user=106
+... [section]
+... a=1;
+... b=2;
+... c=3;
+odd section with comment: e=0 user=107

--- a/tests/unittest_string.c
+++ b/tests/unittest_string.c
@@ -39,5 +39,7 @@ int main(void)
     parse("long line", "[sec]\nfoo = 01234567890123456789\nbar=4321\n");
     parse("long continued", "[sec]\nfoo = 0123456789012bix=1234\n");
     parse("error", "[s]\na=1\nb\nc=3");
+    parse("odd section", "[sec[tio]n]\na=1\nb=2\nc=3");
+    parse("odd section with comment", "[section] ; foo ]\na=1\nb=2\nc=3");
     return 0;
 }


### PR DESCRIPTION
In some cases, a section name might contain a `]`.
Make sure it gets included in the section name by using the last non-comment `]` as end-of-section.

For my specific use-case, the section names contain regular expressions which might have `[` and `]`.