### PR TITLE
enable lineno by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can control various aspects of inih using preprocessor defines:
 ### Parsing options ###
 
   * **Stop on first error:** By default, inih keeps parsing the rest of the file after an error. To stop parsing on the first error, add `-DINI_STOP_ON_FIRST_ERROR=1`.
-  * **Report line numbers:** By default, the `ini_handler` callback doesn't receive the line number as a parameter. If you need that, add `-DINI_HANDLER_LINENO=1`.
+  * **Report line numbers:** By default, the `ini_handler` callback receives the line number as a parameter. If you don't need that, add `-DINI_HANDLER_LINENO=0`.
   * **Call handler on new section:** By default, inih only calls the handler on each `name=value` pair. To detect new sections (e.g., the INI file has multiple sections with the same name), add `-DINI_CALL_HANDLER_ON_NEW_SECTION=1`. Your handler function will then be called each time a new section is encountered, with `section` set to the new section name but `name` and `value` set to NULL.
 
 ### Memory options ###

--- a/ini.h
+++ b/ini.h
@@ -23,7 +23,7 @@ extern "C" {
 
 /* Nonzero if ini_handler callback should accept lineno parameter. */
 #ifndef INI_HANDLER_LINENO
-#define INI_HANDLER_LINENO 0
+#define INI_HANDLER_LINENO 1
 #endif
 
 /* Typedef for prototype of handler function. */

--- a/meson.build
+++ b/meson.build
@@ -34,8 +34,8 @@ else
     if get_option('stop_on_first_error')
         arg_static += ['-DINI_STOP_ON_FIRST_ERROR=1']
     endif
-    if get_option('report_line_numbers')
-        arg_static += ['-DINI_HANDLER_LINENO=1']
+    if not get_option('report_line_numbers')
+        arg_static += ['-DINI_HANDLER_LINENO=0']
     endif
     if get_option('call_handler_on_new_section')
         arg_static += ['-DINI_CALL_HANDLER_ON_NEW_SECTION=1']

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -45,7 +45,7 @@ option('stop_on_first_error',
 )
 option('report_line_numbers',
   type : 'boolean',
-  value : false,
+  value : true,
   description : 'report line number on ini_handler callback'
 )
 option('call_handler_on_new_section',

--- a/tests/unittest.sh
+++ b/tests/unittest.sh
@@ -1,57 +1,57 @@
 #!/usr/bin/env bash
 
-gcc ../ini.c unittest.c -o unittest_multi
+gcc ../ini.c -DINI_HANDLER_LINENO=0 unittest.c -o unittest_multi
 ./unittest_multi > baseline_multi.txt
 rm -f unittest_multi
 
-gcc ../ini.c -DINI_MAX_LINE=20 unittest.c -o unittest_multi_max_line
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_MAX_LINE=20 unittest.c -o unittest_multi_max_line
 ./unittest_multi_max_line > baseline_multi_max_line.txt
 rm -f unittest_multi_max_line
 
-gcc ../ini.c -DINI_ALLOW_MULTILINE=0 unittest.c -o unittest_single
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_ALLOW_MULTILINE=0 unittest.c -o unittest_single
 ./unittest_single > baseline_single.txt
 rm -f unittest_single
 
-gcc ../ini.c -DINI_ALLOW_INLINE_COMMENTS=0 unittest.c -o unittest_disallow_inline_comments
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_ALLOW_INLINE_COMMENTS=0 unittest.c -o unittest_disallow_inline_comments
 ./unittest_disallow_inline_comments > baseline_disallow_inline_comments.txt
 rm -f unittest_disallow_inline_comments
 
-gcc ../ini.c -DINI_STOP_ON_FIRST_ERROR=1 unittest.c -o unittest_stop_on_first_error
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_STOP_ON_FIRST_ERROR=1 unittest.c -o unittest_stop_on_first_error
 ./unittest_stop_on_first_error > baseline_stop_on_first_error.txt
 rm -f unittest_stop_on_first_error
 
-gcc ../ini.c -DINI_HANDLER_LINENO=1 unittest.c -o unittest_handler_lineno
+gcc ../ini.c unittest.c -o unittest_handler_lineno
 ./unittest_handler_lineno > baseline_handler_lineno.txt
 rm -f unittest_handler_lineno
 
-gcc ../ini.c -DINI_MAX_LINE=20 unittest_string.c -o unittest_string
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_MAX_LINE=20 unittest_string.c -o unittest_string
 ./unittest_string > baseline_string.txt
 rm -f unittest_string
 
-gcc ../ini.c -DINI_USE_STACK=0 unittest.c -o unittest_heap
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_USE_STACK=0 unittest.c -o unittest_heap
 ./unittest_heap > baseline_heap.txt
 rm -f unittest_heap
 
-gcc ../ini.c -DINI_USE_STACK=0 -DINI_MAX_LINE=20 -DINI_INITIAL_ALLOC=20 unittest.c -o unittest_heap_max_line
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_USE_STACK=0 -DINI_MAX_LINE=20 -DINI_INITIAL_ALLOC=20 unittest.c -o unittest_heap_max_line
 ./unittest_heap_max_line > baseline_heap_max_line.txt
 rm -f unittest_heap_max_line
 
-gcc ../ini.c -DINI_USE_STACK=0 -DINI_ALLOW_REALLOC=1 -DINI_INITIAL_ALLOC=5 unittest.c -o unittest_heap_realloc
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_USE_STACK=0 -DINI_ALLOW_REALLOC=1 -DINI_INITIAL_ALLOC=5 unittest.c -o unittest_heap_realloc
 ./unittest_heap_realloc > baseline_heap_realloc.txt
 rm -f unittest_heap_realloc
 
-gcc ../ini.c -DINI_USE_STACK=0 -DINI_MAX_LINE=20 -DINI_ALLOW_REALLOC=1 -DINI_INITIAL_ALLOC=5 unittest.c -o unittest_heap_realloc_max_line
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_USE_STACK=0 -DINI_MAX_LINE=20 -DINI_ALLOW_REALLOC=1 -DINI_INITIAL_ALLOC=5 unittest.c -o unittest_heap_realloc_max_line
 ./unittest_heap_realloc_max_line > baseline_heap_realloc_max_line.txt
 rm -f unittest_heap_realloc_max_line
 
-gcc ../ini.c -DINI_USE_STACK=0 -DINI_MAX_LINE=20 -DINI_INITIAL_ALLOC=20 unittest_string.c -o unittest_heap_string
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_USE_STACK=0 -DINI_MAX_LINE=20 -DINI_INITIAL_ALLOC=20 unittest_string.c -o unittest_heap_string
 ./unittest_heap_string > baseline_heap_string.txt
 rm -f unittest_heap_string
 
-gcc ../ini.c -DINI_CALL_HANDLER_ON_NEW_SECTION=1 unittest.c -o unittest_call_handler_on_new_section
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_CALL_HANDLER_ON_NEW_SECTION=1 unittest.c -o unittest_call_handler_on_new_section
 ./unittest_call_handler_on_new_section > baseline_call_handler_on_new_section.txt
 rm -f unittest_call_handler_on_new_section
 
-gcc ../ini.c -DINI_ALLOW_NO_VALUE=1 unittest.c -o unittest_allow_no_value
+gcc ../ini.c -DINI_HANDLER_LINENO=0 -DINI_ALLOW_NO_VALUE=1 unittest.c -o unittest_allow_no_value
 ./unittest_allow_no_value > baseline_allow_no_value.txt
 rm -f unittest_allow_no_value


### PR DESCRIPTION
Pretty straight forward, doesn't change any functionality.

This is mainly useful when building the shared lib, because passing a build option can't change the header file. This is also the behavior of the shared lib in Debian ([patch](https://salsa.debian.org/yangfl-guest/inih/-/blob/33817ff191963d08d8de4a06534471cb4333fb9b/debian/patches/0005-Force-INI_HANDLER_LINENO.patch)).

The only thing I'm not completely happy with are the tests, as the script now looks a bit more ugly. If it bothers you, I'm sure I can come up with a cleaner solution.