### PR TITLE
enable distro settings by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Some differences between inih and Python's [ConfigParser](http://docs.python.org
 * All compile-time options are implemented in Meson as well, you can take a look at [meson_options.txt](https://github.com/benhoyt/inih/blob/master/meson_options.txt) for their definition. These won't work if `distro_install` is set to `true`.
 * If you want to use inih for programs which may be shipped in a distro, consider linking against the shared libraries. The pkg-config entries are `inih` and `INIReader`.
 * In case you use inih as a Meson subproject, you can use the `inih_dep` and `INIReader_dep` dependency variables. You might want to set `default_library=static` and `distro_install=false` for the subproject. An official Wrap is provided on [WrapDB](https://wrapdb.mesonbuild.com/inih).
+* For packagers: if you want to tag the version in the pkg-config file, you will need to do this downstream. Add `version : '<version_as_int>',` after the `license` tag in the `project()` function and `version : meson.project_version(),` after the `soversion` tag in both `library()` functions.
 
 ## Building from vcpkg ##
 

--- a/README.md
+++ b/README.md
@@ -132,13 +132,13 @@ Some differences between inih and Python's [ConfigParser](http://docs.python.org
 ## Meson notes ##
 
 * The `meson.build` file is not required to use or compile inih, its main purpose is for distributions.
-* By default Meson only creates a static library for inih, but Meson can be used to configure this behavior:
-* with `-Ddefault_library=shared` a shared library is build.
-* with `-Ddistro_install=true` the library will be installed with the header and a pkg-config entry, you may want to set `-Ddefault_library=shared` when using this.
-* with `-Dwith_INIReader` you can build (and install if selected) the C++ library.
-* all compile-time options are implemented in Meson as well, you can take a look at [meson_options.txt](https://github.com/benhoyt/inih/blob/master/meson_options.txt) for their definition. These won't work if `distro_install` is set to `true`.
+* By default Meson is set up for distro installation, but this behavior can be configured for embedded use cases:
+  * with `-Ddefault_library=static` static libraries are built.
+  * with `-Ddistro_install=false` libraries, headers and pkg-config files won't be installed.
+  * with `-Dwith_INIReader=false` you can disable building the C++ library.
+* All compile-time options are implemented in Meson as well, you can take a look at [meson_options.txt](https://github.com/benhoyt/inih/blob/master/meson_options.txt) for their definition. These won't work if `distro_install` is set to `true`.
 * If you want to use inih for programs which may be shipped in a distro, consider linking against the shared libraries. The pkg-config entries are `inih` and `INIReader`.
-* In case you use inih as a subproject, you can use the `inih_dep` and `INIReader_dep` dependency variables.
+* In case you use inih as a Meson subproject, you can use the `inih_dep` and `INIReader_dep` dependency variables. You might want to set `default_library=static` and `distro_install=false` for the subproject. An official Wrap is provided on [WrapDB](https://wrapdb.mesonbuild.com/inih).
 
 ## Building from vcpkg ##
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,5 @@
 project('inih',
     ['c'],
-    default_options : ['default_library=static'],
     license : 'BSD-3-Clause',
 )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,11 +1,11 @@
 option('distro_install',
   type : 'boolean',
-  value : false,
+  value : true,
   description : 'install shared libs, headers and pkg-config entries'
 )
 option('with_INIReader',
   type : 'boolean',
-  value : false,
+  value : true,
   description : 'compile and (if selected) install INIReader'
 )
 option('multi-line_entries',


### PR DESCRIPTION
inih as a shared library becomes increasingly popular and is even used by xfsprogs now. Because of that, I think it's a good idea to enable these settings in Meson by default. Since Meson supports individual settings per subproject, this won't break any use case.

I also added a small note so that issues like #123 don't appear again.
