### PR TITLE
meson: add static compile args to inih_dep

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,7 @@ endif
 
 inih_dep = declare_dependency(
     link_with : lib_inih,
+    compile_args : arg_static,
     include_directories : inc_inih
 )
 


### PR DESCRIPTION
Just noticed a small bug, when setting static compile commands in Meson, they haven't been applied to objects that depend on it. Since this might created some bugs, it would be cool if you could tag this a new release (even though no code changed since r52).