### PR TITLE
meson.build: define version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('inih',
     ['c'],
     license : 'BSD-3-Clause',
+    version : '54',
 )
 
 #### options ####


### PR DESCRIPTION
Otherwise, the installed .pc file contains "Version: undefined".

Signed-off-by: Sam James <sam@gentoo.org>