### PR TITLE
Make inline comments work on subsequent lines of multiline values

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -171,6 +171,12 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
         }
 #if INI_ALLOW_MULTILINE
         else if (*prev_name && *start && start > line) {
+#if INI_ALLOW_INLINE_COMMENTS
+            end = find_chars_or_comment(start, NULL);
+            if (*end)
+                *end = '\0';
+            rstrip(start);
+#endif
             /* Non-blank line with leading whitespace, treat as continuation
                of previous name's value (as per Python configparser). */
             if (!HANDLER(user, section, prev_name, start) && !error)

--- a/tests/baseline_allow_no_value.txt
+++ b/tests/baseline_allow_no_value.txt
@@ -46,6 +46,8 @@ user_error.ini: e=3 user=104
 ... multi=the quick;
 ... multi=brown fox;
 ... name=bob smith;
+... foo=bar;
+... foo=Hi World;
 multi_line.ini: e=0 user=105
 ... indented;
 bad_multi.ini: e=0 user=106

--- a/tests/baseline_call_handler_on_new_section.txt
+++ b/tests/baseline_call_handler_on_new_section.txt
@@ -46,6 +46,8 @@ user_error.ini: e=3 user=104
 ... multi=the quick;
 ... multi=brown fox;
 ... name=bob smith;
+... foo=bar;
+... foo=Hi World;
 multi_line.ini: e=0 user=105
 bad_multi.ini: e=1 user=105
 ... [bom_section]

--- a/tests/baseline_disallow_inline_comments.txt
+++ b/tests/baseline_disallow_inline_comments.txt
@@ -46,6 +46,8 @@ user_error.ini: e=3 user=104
 ... multi=the quick;
 ... multi=brown fox;
 ... name=bob smith  ; comment line 1;
+... foo=bar ;c1;
+... foo=Hi World ;c2;
 multi_line.ini: e=0 user=105
 bad_multi.ini: e=1 user=105
 ... [bom_section]

--- a/tests/baseline_handler_lineno.txt
+++ b/tests/baseline_handler_lineno.txt
@@ -45,6 +45,8 @@ user_error.ini: e=3 user=104
 ... multi=the quick;  line 12
 ... multi=brown fox;  line 13
 ... name=bob smith;  line 14
+... foo=bar;  line 16
+... foo=Hi World;  line 17
 multi_line.ini: e=0 user=105
 bad_multi.ini: e=1 user=105
 ... [bom_section]

--- a/tests/baseline_heap.txt
+++ b/tests/baseline_heap.txt
@@ -45,6 +45,8 @@ user_error.ini: e=3 user=104
 ... multi=the quick;
 ... multi=brown fox;
 ... name=bob smith;
+... foo=bar;
+... foo=Hi World;
 multi_line.ini: e=0 user=105
 bad_multi.ini: e=1 user=105
 ... [bom_section]

--- a/tests/baseline_heap_max_line.txt
+++ b/tests/baseline_heap_max_line.txt
@@ -49,6 +49,8 @@ user_error.ini: e=3 user=104
 ... name=bob smith;
 ... name=comment line 1;
 ... name=comment line 2;
+... foo=bar;
+... foo=Hi World;
 multi_line.ini: e=5 user=105
 bad_multi.ini: e=1 user=105
 ... [bom_section]

--- a/tests/baseline_heap_realloc.txt
+++ b/tests/baseline_heap_realloc.txt
@@ -45,6 +45,8 @@ user_error.ini: e=3 user=104
 ... multi=the quick;
 ... multi=brown fox;
 ... name=bob smith;
+... foo=bar;
+... foo=Hi World;
 multi_line.ini: e=0 user=105
 bad_multi.ini: e=1 user=105
 ... [bom_section]

--- a/tests/baseline_heap_realloc_max_line.txt
+++ b/tests/baseline_heap_realloc_max_line.txt
@@ -49,6 +49,8 @@ user_error.ini: e=3 user=104
 ... name=bob smith;
 ... name=comment line 1;
 ... name=comment line 2;
+... foo=bar;
+... foo=Hi World;
 multi_line.ini: e=5 user=105
 bad_multi.ini: e=1 user=105
 ... [bom_section]

--- a/tests/baseline_multi.txt
+++ b/tests/baseline_multi.txt
@@ -45,6 +45,8 @@ user_error.ini: e=3 user=104
 ... multi=the quick;
 ... multi=brown fox;
 ... name=bob smith;
+... foo=bar;
+... foo=Hi World;
 multi_line.ini: e=0 user=105
 bad_multi.ini: e=1 user=105
 ... [bom_section]

--- a/tests/baseline_multi_max_line.txt
+++ b/tests/baseline_multi_max_line.txt
@@ -49,6 +49,8 @@ user_error.ini: e=3 user=104
 ... name=bob smith;
 ... name=comment line 1;
 ... name=comment line 2;
+... foo=bar;
+... foo=Hi World;
 multi_line.ini: e=5 user=105
 bad_multi.ini: e=1 user=105
 ... [bom_section]

--- a/tests/baseline_single.txt
+++ b/tests/baseline_single.txt
@@ -41,6 +41,7 @@ user_error.ini: e=3 user=104
 ... single=ghi;
 ... multi=the quick;
 ... name=bob smith;
+... foo=bar;
 multi_line.ini: e=4 user=105
 bad_multi.ini: e=1 user=105
 ... [bom_section]

--- a/tests/baseline_stop_on_first_error.txt
+++ b/tests/baseline_stop_on_first_error.txt
@@ -43,6 +43,8 @@ user_error.ini: e=3 user=104
 ... multi=the quick;
 ... multi=brown fox;
 ... name=bob smith;
+... foo=bar;
+... foo=Hi World;
 multi_line.ini: e=0 user=105
 bad_multi.ini: e=1 user=105
 ... [bom_section]

--- a/tests/multi_line.ini
+++ b/tests/multi_line.ini
@@ -13,3 +13,5 @@ multi: the quick
        brown fox
 name = bob smith  ; comment line 1
                   ; comment line 2
+foo = bar ;c1
+      Hi World ;c2


### PR DESCRIPTION
This is a bug fix that makes inih's behaviour here work as per Python's
ConfigParser, which is what inih behaviour is (loosely) based on.

Thanks @silly2020 for the report. See
https://github.com/benhoyt/inih/issues/120#issuecomment-1181341960