### PR TITLE
add autotools build and GitHub release workflow

### DIFF
--- a/.build-aux/git-version-gen
+++ b/.build-aux/git-version-gen
@@ -1,0 +1,1 @@
+printf %s "$(git --no-pager describe --abbrev=8 --tags --always --dirty)"

--- a/.github/workflows/build-if-tag-release.yaml
+++ b/.github/workflows/build-if-tag-release.yaml
@@ -1,0 +1,23 @@
+name: build (and if tag, release)
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: autoconf
+        run: autoreconf -fi
+      - name: configure
+        run: ./configure
+      - name: build
+        run: make
+      - name: check
+        run: make check
+      - name: distcheck
+        run: make distcheck
+      - name: release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/r')
+        with:
+          files: '*.tar.xz'

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,17 @@
+ACLOCAL_AMFLAGS = -I .build-aux/m4
+
+lib_LTLIBRARIES = libinih.la
+
+pkgconfig_DATA = inih.pc
+
+dist_doc_DATA = README.md LICENSE.txt
+
+# dist_noinst_DATA = meson.build meson_options.txt
+
+EXTRA_DIST = .build-aux/git-version-gen
+
+pkginclude_HEADERS = ini.h
+libinih_la_SOURCES = ini.c
+
+libinih_la_CFLAGS = $(AM_CFLAGS)
+libinih_la_LDFLAGS = -module -shared -export-dynamic -version-info 0:1

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,24 @@
+AC_INIT([inih],
+	m4_esyscmd([.build-aux/git-version-gen .tarball-version]),
+	[https://github.com/bluesquall/inih/issues],
+	[],
+	[https://github.com/bluesquall/inih],
+)
+AC_CONFIG_AUX_DIR([.build-aux])
+AC_CONFIG_MACRO_DIRS([.build-aux/m4])
+AC_CONFIG_HEADERS([config.h])
+AM_INIT_AUTOMAKE([subdir-objects dist-xz -Wall -Wno-portability foreign])
+
+PKG_PROG_PKG_CONFIG
+PKG_INSTALLDIR
+
+AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([inih.pc:inih.pc.in])
+
+AM_PROG_AR
+AC_PROG_LIBTOOL
+AM_PROG_CC_C_O
+AC_PROG_CC_STDC
+AC_OUTPUT
+
+LT_INIT([dlopen])

--- a/configure.ac
+++ b/configure.ac
@@ -7,18 +7,16 @@ AC_INIT([inih],
 AC_CONFIG_AUX_DIR([.build-aux])
 AC_CONFIG_MACRO_DIRS([.build-aux/m4])
 AC_CONFIG_HEADERS([config.h])
-AM_INIT_AUTOMAKE([subdir-objects dist-xz -Wall -Wno-portability foreign])
+AM_INIT_AUTOMAKE([subdir-objects dist-xz no-dist-gzip -Wall -Wno-portability foreign])
+AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([inih.pc:inih.pc.in])
 
 PKG_PROG_PKG_CONFIG
 PKG_INSTALLDIR
 
-AC_CONFIG_FILES([Makefile])
-AC_CONFIG_FILES([inih.pc:inih.pc.in])
-
 AM_PROG_AR
 AC_PROG_LIBTOOL
-AM_PROG_CC_C_O
-AC_PROG_CC_STDC
+AC_PROG_CC
 AC_OUTPUT
 
 LT_INIT([dlopen])

--- a/inih.pc.in
+++ b/inih.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+inih_db_dir=@sysconfdir@/inih/db
+
+Name: @PACKAGE_NAME@
+Description: a simple .ini file parser written in C
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -linih
+Cflags: -I${includedir}/inih


### PR DESCRIPTION
Here's a set of changes that will support the autotools build of a shared & static libraries, and a GitHub release workflow to put the `distcheck`'ed tarball on the release page.

I need these things for a build on a legacy system, and figured they may be useful to others. I could also draft a CMake build, if you're interested.