### PR TITLE
MSVC throws C4244

### DIFF
--- a/cpp/INIReader.cpp
+++ b/cpp/INIReader.cpp
@@ -69,7 +69,8 @@ bool INIReader::GetBoolean(const string& section, const string& name, bool defau
 {
     string valstr = Get(section, name, "");
     // Convert to lower case to make string comparisons case-insensitive
-    std::transform(valstr.begin(), valstr.end(), valstr.begin(), ::tolower);
+    std::transform(valstr.begin(), valstr.end(), valstr.begin(),
+        [](const unsigned char& ch) { return static_cast<unsigned char>(::tolower(ch)); });
     if (valstr == "true" || valstr == "yes" || valstr == "on" || valstr == "1")
         return true;
     else if (valstr == "false" || valstr == "no" || valstr == "off" || valstr == "0")
@@ -98,7 +99,8 @@ string INIReader::MakeKey(const string& section, const string& name)
 {
     string key = section + "=" + name;
     // Convert to lower case to make section/name lookups case-insensitive
-    std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+    std::transform(key.begin(), key.end(), key.begin(),
+        [](const unsigned char& ch) { return static_cast<unsigned char>(::tolower(ch)); });
     return key;
 }
 


### PR DESCRIPTION
MSVC 14.32.3132 throws C4244 when compiling INIReader.cpp.
```
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\include\algorithm(3031,24): warning C4244: '=': conversion from 'int' to 'char', possible loss of data
1>...\Lib\inih\cpp\INIReader.cpp(72): message : see reference to function template instantiation '_OutIt std::transform<std::_String_iterator<std::_String_val<std::_Simple_types<_Elem>>>,std::_String_iterator<std::_String_val<std::_Simple_types<_Elem>>>,int(__cdecl *)(int)>(const _InIt,const _InIt,_OutIt,_Fn)' being compiled
1>        with
1>        [
1>            _OutIt=std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,
1>            _Elem=char,
1>            _InIt=std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,
1>            _Fn=int (__cdecl *)(int)
1>        ]
```
This PR fixes this, by using a lambda which static casts the return value of ::tolower into an unsigned char.

TLDR:
- ::tolower returns int
- MSVC throws the warning C4244: conversion from 'int' to 'char'
- this lambda static casts the return value back to char