### PR TITLE
remove quotes from parsed values

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -48,7 +48,11 @@ typedef struct {
 static char* rstrip(char* s)
 {
     char* p = s + strlen(s);
+#if INI_NO_STRING_QUOTE
+    while (p > s && (isspace((unsigned char)(*--p)) || (unsigned char)(*p) == '"'))
+#else
     while (p > s && isspace((unsigned char)(*--p)))
+#endif
         *p = '\0';
     return s;
 }
@@ -56,7 +60,11 @@ static char* rstrip(char* s)
 /* Return pointer to first non-whitespace char in given string. */
 static char* lskip(const char* s)
 {
+#if INI_NO_STRING_QUOTE
+    while (*s && (isspace((unsigned char)(*s)) || (unsigned char)(*s) == '"'))
+#else
     while (*s && isspace((unsigned char)(*s)))
+#endif
         s++;
     return (char*)s;
 }

--- a/ini.h
+++ b/ini.h
@@ -170,6 +170,13 @@ INI_API int ini_parse_string(const char* string, ini_handler handler, void* user
 #define INI_CUSTOM_ALLOCATOR 0
 #endif
 
+/* Nonzero to remove string quoting from settings. Settings could be saved with
+   quotes and sometimes is useful having the clean value parsed*/
+#ifndef INI_NO_STRING_QUOTE
+#define INI_NO_STRING_QUOTE 1
+#endif
+
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Removing quotes while parsin if the INI_NO_STRING_QUOTE is enabled.

Signed-off-by: Angelo Compagnucci <angelo@amarulasolutions.com>