### PR TITLE
Fixed handling of long strings when using INI_USE_STACK

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -156,6 +156,14 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
 
         lineno++;
 
+#if INI_USE_STACK
+        if (strlen(line) == max_line - 1 && line[max_line - 2] != '\n') {
+            /* Exit even if INI_STOP_ON_FIRST_ERROR is not set */
+            error = lineno;
+            break;
+        }
+#endif
+
         start = line;
 #if INI_ALLOW_BOM
         if (lineno == 1 && (unsigned char)start[0] == 0xEF &&


### PR DESCRIPTION
Undefined behavior occurred if the incoming .ini file contains a line that is longer than INI_MAX_LINE with the INI_USE_STACK option. In such a case, it is safe to abort parsing even if INI_STOP_ON_FIRST_ERROR is not set.

See https://github.com/benhoyt/inih/issues/145 for the details

Signed-off-by: Mikhail Khachayants <tyler92@inbox.ru>