### PR TITLE
meson.build: fix start-of-line_comment_prefix variable name

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ else
     endif
     sol_comment_prefix = get_option('start-of-line_comment_prefix')
     if sol_comment_prefix != ';#'
-        arg_static += ['-DINI_START_COMMENT_PREFIXES="' + start-of-line_comment_prefix + '"']
+        arg_static += ['-DINI_START_COMMENT_PREFIXES="' + sol_comment_prefix + '"']
     endif
     if get_option('allow_no_value')
         arg_static += ['-DINI_ALLOW_NO_VALUE=1']


### PR DESCRIPTION
`start-of-line_comment_prefix` is not a valid identifier in Meson.  It looks like this was partially addressed with `sol_comment_prefix` but didn't make it into actual usage.