### PR TITLE
Specify C++11 std in meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,8 @@
 project('inih',
     ['c'],
     license : 'BSD-3-Clause',
-    version : '56',
+    version : '57',
+    default_options : ['cpp_std=c++11']
 )
 
 #### options ####


### PR DESCRIPTION
Compilers differ on what the default standard is and I had to set C++11 standard as part of the [vcpkg port](https://github.com/microsoft/vcpkg/pull/33001) to get it work on MacOS.
Consequence of #142 

I wasn't sure what standard version to put for C so I left it out.

Also you forgot to bump the version number last release.