### PR TITLE
Update INIReader.cpp

### DIFF
--- a/cpp/INIReader.cpp
+++ b/cpp/INIReader.cpp
@@ -17,7 +17,7 @@
 
 using std::string;
 
-INIReader::INIReader(const string& filename)
+INIReader::INIReader(const std::string& filename)
 {
     _error = ini_parse(filename.c_str(), ValueHandler, this);
 }


### PR DESCRIPTION
Update INIReader::INIReader prototype implementation to match header implementation.
This update is removing the warning when generating Doxygen documentation.