### PR TITLE
Swap rstrip() and lskip() to reduce execution time of strlen()

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -164,7 +164,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
             start += 3;
         }
 #endif
-        start = ini_lskip(ini_rstrip(start));
+        start = ini_rstrip(ini_lskip(start));
 
         if (strchr(INI_START_COMMENT_PREFIXES, *start)) {
             /* Start-of-line comment */


### PR DESCRIPTION
I confess that the optimization is minimal. But it is free because it does not complicates the code.

With this change, I measured the time spent on the first call of `strlen()`:

```
$ python3 -c 'print(" "*4000 + "name=value")' > long_padding.ini
$ gcc examples/ini_dump.c ini.c -o examples/ini_dump
$ ltrace -T -e strlen ./examples/ini_dump long_padding.ini
ini_dump->strlen("name=value\n")                                     = 11 <0.000147>
```

and without this change (master):

```
ini_dump->strlen("                                "...)              = 4011 <0.001856>
```

The execution time was reduced from `1856 ns` to `147 ns`.