### PR TITLE
Add preprocessor exclusions when INI_ALLOW_MULTILINE=0

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -110,7 +110,9 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
     size_t offset;
 #endif
     char section[MAX_SECTION] = "";
+#if INI_ALLOW_MULTILINE
     char prev_name[MAX_NAME] = "";
+#endif
 
     char* start;
     char* end;
@@ -189,7 +191,9 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
             if (*end == ']') {
                 *end = '\0';
                 ini_strncpy0(section, start + 1, sizeof(section));
+#if INI_ALLOW_MULTILINE
                 *prev_name = '\0';
+#endif
 #if INI_CALL_HANDLER_ON_NEW_SECTION
                 if (!HANDLER(user, section, NULL, NULL) && !error)
                     error = lineno;
@@ -215,8 +219,10 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                 value = ini_lskip(value);
                 ini_rstrip(value);
 
-                /* Valid name[=:]value pair found, call handler */
+#if INI_ALLOW_MULTILINE
                 ini_strncpy0(prev_name, name, sizeof(prev_name));
+#endif
+                /* Valid name[=:]value pair found, call handler */
                 if (!HANDLER(user, section, name, value) && !error)
                     error = lineno;
             }


### PR DESCRIPTION
Exclude the `prev_name` variable and the ini_strncpy0() call.

This decreases the program size, the execution time and the stack usage when that flag is off.

But that's barely noticeable. It's more useful for progressive understanding.
When I first came across with this code, I removed (or collapsed) all the `ifdef` blocks to learn the simpler version first.