### PR TITLE
Test that long sections are truncated

### DIFF
--- a/tests/baseline_allow_no_value.txt
+++ b/tests/baseline_allow_no_value.txt
@@ -69,3 +69,6 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=0 user=109
+... [_123456789_123456789_123456789_123456789_12345678]
+... name=value;
+long_section.ini: e=0 user=110

--- a/tests/baseline_call_handler_on_new_section.txt
+++ b/tests/baseline_call_handler_on_new_section.txt
@@ -67,3 +67,6 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... [_123456789_123456789_123456789_123456789_12345678]
+... name=value;
+long_section.ini: e=0 user=110

--- a/tests/baseline_disallow_inline_comments.txt
+++ b/tests/baseline_disallow_inline_comments.txt
@@ -65,3 +65,6 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... [_123456789_123456789_123456789_123456789_12345678]
+... name=value;
+long_section.ini: e=0 user=110

--- a/tests/baseline_handler_lineno.txt
+++ b/tests/baseline_handler_lineno.txt
@@ -64,3 +64,6 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;  line 9
 no_value.ini: e=2 user=109
+... [_123456789_123456789_123456789_123456789_12345678]
+... name=value;  line 3
+long_section.ini: e=0 user=110

--- a/tests/baseline_heap.txt
+++ b/tests/baseline_heap.txt
@@ -64,3 +64,6 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... [_123456789_123456789_123456789_123456789_12345678]
+... name=value;
+long_section.ini: e=0 user=110

--- a/tests/baseline_heap_max_line.txt
+++ b/tests/baseline_heap_max_line.txt
@@ -68,3 +68,5 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... name=value;
+long_section.ini: e=2 user=110

--- a/tests/baseline_heap_max_line.txt
+++ b/tests/baseline_heap_max_line.txt
@@ -68,5 +68,6 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... [_123456789_123456789_123456789_123456789_12345678]
 ... name=value;
 long_section.ini: e=2 user=110

--- a/tests/baseline_heap_max_line.txt
+++ b/tests/baseline_heap_max_line.txt
@@ -68,6 +68,5 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
-... [_123456789_123456789_123456789_123456789_12345678]
 ... name=value;
 long_section.ini: e=2 user=110

--- a/tests/baseline_heap_realloc.txt
+++ b/tests/baseline_heap_realloc.txt
@@ -64,3 +64,6 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... [_123456789_123456789_123456789_123456789_12345678]
+... name=value;
+long_section.ini: e=0 user=110

--- a/tests/baseline_heap_realloc_max_line.txt
+++ b/tests/baseline_heap_realloc_max_line.txt
@@ -68,3 +68,5 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... name=value;
+long_section.ini: e=2 user=110

--- a/tests/baseline_heap_realloc_max_line.txt
+++ b/tests/baseline_heap_realloc_max_line.txt
@@ -68,5 +68,6 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... [_123456789_123456789_123456789_123456789_12345678]
 ... name=value;
 long_section.ini: e=2 user=110

--- a/tests/baseline_heap_realloc_max_line.txt
+++ b/tests/baseline_heap_realloc_max_line.txt
@@ -68,6 +68,5 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
-... [_123456789_123456789_123456789_123456789_12345678]
 ... name=value;
 long_section.ini: e=2 user=110

--- a/tests/baseline_multi.txt
+++ b/tests/baseline_multi.txt
@@ -64,3 +64,6 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... [_123456789_123456789_123456789_123456789_12345678]
+... name=value;
+long_section.ini: e=0 user=110

--- a/tests/baseline_multi_max_line.txt
+++ b/tests/baseline_multi_max_line.txt
@@ -68,3 +68,5 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... name=value;
+long_section.ini: e=2 user=110

--- a/tests/baseline_multi_max_line.txt
+++ b/tests/baseline_multi_max_line.txt
@@ -68,5 +68,6 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... [_123456789_123456789_123456789_123456789_12345678]
 ... name=value;
 long_section.ini: e=2 user=110

--- a/tests/baseline_multi_max_line.txt
+++ b/tests/baseline_multi_max_line.txt
@@ -68,6 +68,5 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
-... [_123456789_123456789_123456789_123456789_12345678]
 ... name=value;
 long_section.ini: e=2 user=110

--- a/tests/baseline_single.txt
+++ b/tests/baseline_single.txt
@@ -59,3 +59,6 @@ duplicate_sections.ini: e=0 user=108
 ... [section1]
 ... key1=val1;
 no_value.ini: e=2 user=109
+... [_123456789_123456789_123456789_123456789_12345678]
+... name=value;
+long_section.ini: e=0 user=110

--- a/tests/baseline_stop_on_first_error.txt
+++ b/tests/baseline_stop_on_first_error.txt
@@ -58,3 +58,6 @@ bom.ini: e=0 user=107
 ... single2=qrs;
 duplicate_sections.ini: e=0 user=108
 no_value.ini: e=2 user=108
+... [_123456789_123456789_123456789_123456789_12345678]
+... name=value;
+long_section.ini: e=0 user=110

--- a/tests/long_section.ini
+++ b/tests/long_section.ini
@@ -1,0 +1,3 @@
+# check that section is truncated
+[_123456789_123456789_123456789_123456789_123456789_123456789]
+name = value

--- a/tests/unittest.c
+++ b/tests/unittest.c
@@ -72,5 +72,6 @@ int main(void)
     parse("bom.ini");
     parse("duplicate_sections.ini");
     parse("no_value.ini");
+    parse("long_section.ini");
     return 0;
 }


### PR DESCRIPTION
- **test that long sections are truncated**
- **generated .txt executing unittest.sh**
- **expected result**


Should we revert the commit 9f0a1d2199b1a9f0a20003d848918a881a2d91e4 to prevent the CI from failing?

It seems related with a more general issue ( #145 )