### PR TITLE
Use 'fopen_s' for Security Reasons

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -264,14 +264,13 @@ int ini_parse(const char* filename, ini_handler handler, void* user)
     FILE* file;
     int error;
 
-    if (fopen_s(&file, filename, "r") != 0) {
+    file = fopen(filename, "r");
+    if (!file)
         return -1;
-    }
     error = ini_parse_file(file, handler, user);
     fclose(file);
     return error;
 }
-
 
 /* An ini_reader function to read the next line from a string buffer. This
    is the fgets() equivalent used by ini_parse_string(). */

--- a/ini.c
+++ b/ini.c
@@ -264,9 +264,9 @@ int ini_parse(const char* filename, ini_handler handler, void* user)
     FILE* file;
     int error;
 
-    file = fopen(filename, "r");
-    if (!file)
+    if(fopen_s(&file, filename, "r") != 0) {
         return -1;
+    }
     error = ini_parse_file(file, handler, user);
     fclose(file);
     return error;

--- a/ini.c
+++ b/ini.c
@@ -264,13 +264,14 @@ int ini_parse(const char* filename, ini_handler handler, void* user)
     FILE* file;
     int error;
 
-    file = fopen(filename, "r");
-    if (!file)
+    if (fopen_s(&file, filename, "r") != 0) {
         return -1;
+    }
     error = ini_parse_file(file, handler, user);
     fclose(file);
     return error;
 }
+
 
 /* An ini_reader function to read the next line from a string buffer. This
    is the fgets() equivalent used by ini_parse_string(). */


### PR DESCRIPTION
**Description**
This pull request replaces the `fopen` function with the safer `fopen_s` function to enhance security and error handling. The `fopen_s` function provides better safeguards against potential vulnerabilities associated with file opening.

**Changes Made**

- Replaced `fopen` with `fopen_s` for opening files.

**Justification**
- [fopen_s on MSDN](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-s-wfopen-s?view=msvc-160)