### PR TITLE
Fix bug where name only options are not processed after an error has occurred

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -238,7 +238,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                 if (!HANDLER(user, section, name, value) && !error)
                     error = lineno;
             }
-            else if (!error) {
+            else {
                 /* No '=' or ':' found on name[=:]value line */
 #if INI_ALLOW_NO_VALUE
                 *end = '\0';
@@ -246,7 +246,8 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                 if (!HANDLER(user, section, name, NULL) && !error)
                     error = lineno;
 #else
-                error = lineno;
+                if (!error)
+                    error = lineno;
 #endif
             }
         }

--- a/tests/baseline_allow_no_value.txt
+++ b/tests/baseline_allow_no_value.txt
@@ -83,3 +83,5 @@ long_section.ini: e=0 user=110
 ... [no trailing \n]
 ... _123456782=12345678;
 long_line.ini: e=0 user=111
+... name;
+name_only_after_error.ini: e=5 user=112

--- a/tests/baseline_call_handler_on_new_section.txt
+++ b/tests/baseline_call_handler_on_new_section.txt
@@ -81,3 +81,4 @@ long_section.ini: e=0 user=110
 ... [no trailing \n]
 ... _123456782=12345678;
 long_line.ini: e=0 user=111
+name_only_after_error.ini: e=5 user=111

--- a/tests/baseline_disallow_inline_comments.txt
+++ b/tests/baseline_disallow_inline_comments.txt
@@ -79,3 +79,4 @@ long_section.ini: e=0 user=110
 ... [no trailing \n]
 ... _123456782=12345678;
 long_line.ini: e=0 user=111
+name_only_after_error.ini: e=5 user=111

--- a/tests/baseline_handler_lineno.txt
+++ b/tests/baseline_handler_lineno.txt
@@ -78,3 +78,4 @@ long_section.ini: e=0 user=110
 ... [no trailing \n]
 ... _123456782=12345678;  line 23
 long_line.ini: e=0 user=111
+name_only_after_error.ini: e=5 user=111

--- a/tests/baseline_heap.txt
+++ b/tests/baseline_heap.txt
@@ -78,3 +78,4 @@ long_section.ini: e=0 user=110
 ... [no trailing \n]
 ... _123456782=12345678;
 long_line.ini: e=0 user=111
+name_only_after_error.ini: e=5 user=111

--- a/tests/baseline_heap_max_line.txt
+++ b/tests/baseline_heap_max_line.txt
@@ -77,3 +77,4 @@ long_section.ini: e=1 user=110
 ... [no trailing \n]
 ... _123456782=12345678;
 long_line.ini: e=10 user=111
+name_only_after_error.ini: e=1 user=111

--- a/tests/baseline_heap_realloc.txt
+++ b/tests/baseline_heap_realloc.txt
@@ -78,3 +78,4 @@ long_section.ini: e=0 user=110
 ... [no trailing \n]
 ... _123456782=12345678;
 long_line.ini: e=0 user=111
+name_only_after_error.ini: e=5 user=111

--- a/tests/baseline_heap_realloc_max_line.txt
+++ b/tests/baseline_heap_realloc_max_line.txt
@@ -77,3 +77,4 @@ long_section.ini: e=1 user=110
 ... [no trailing \n]
 ... _123456782=12345678;
 long_line.ini: e=10 user=111
+name_only_after_error.ini: e=1 user=111

--- a/tests/baseline_multi.txt
+++ b/tests/baseline_multi.txt
@@ -78,3 +78,4 @@ long_section.ini: e=0 user=110
 ... [no trailing \n]
 ... _123456782=12345678;
 long_line.ini: e=0 user=111
+name_only_after_error.ini: e=5 user=111

--- a/tests/baseline_multi_max_line.txt
+++ b/tests/baseline_multi_max_line.txt
@@ -77,3 +77,4 @@ long_section.ini: e=1 user=110
 ... [no trailing \n]
 ... _123456782=12345678;
 long_line.ini: e=10 user=111
+name_only_after_error.ini: e=1 user=111

--- a/tests/baseline_single.txt
+++ b/tests/baseline_single.txt
@@ -73,3 +73,4 @@ long_section.ini: e=0 user=110
 ... [no trailing \n]
 ... _123456782=12345678;
 long_line.ini: e=0 user=111
+name_only_after_error.ini: e=5 user=111

--- a/tests/baseline_stop_on_first_error.txt
+++ b/tests/baseline_stop_on_first_error.txt
@@ -72,3 +72,4 @@ long_section.ini: e=0 user=110
 ... [no trailing \n]
 ... _123456782=12345678;
 long_line.ini: e=0 user=111
+name_only_after_error.ini: e=5 user=111

--- a/tests/name_only_after_error.ini
+++ b/tests/name_only_after_error.ini
@@ -1,0 +1,8 @@
+; Test case to ensure name only options are still processed after an error if
+; INI_ALLOW_NO_VALUE is set.
+
+; Deliberately cause an error due to unterminated section.
+[broken
+
+; This should still be processed (unless INI_STOP_ON_FIRST_ERROR is set).
+name

--- a/tests/unittest.c
+++ b/tests/unittest.c
@@ -81,5 +81,6 @@ int main(void)
     parse("no_value.ini");
     parse("long_section.ini");
     parse("long_line.ini");
+    parse("name_only_after_error.ini");
     return 0;
 }


### PR DESCRIPTION
After an error has occurred the expected behaviour is for parsing to continue unless the `INI_STOP_ON_FIRST_ERROR` option is set. However when `INI_ALLOW_NO_VALUE` is set name only options are currently silently ignored after an error. 

This fixes that minor bug and adds a new test case because it is not exposed by any of the existing ones.