### PR TITLE
Better handle `INI_MAX_LINE <= INI_INITIAL_ALLOC`

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -140,7 +140,8 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
         offset = strlen(line);
 
 #if INI_ALLOW_REALLOC && !INI_USE_STACK
-        while (offset == max_line - 1 && line[offset - 1] != '\n') {
+        while (max_line < INI_MAX_LINE &&
+               offset == max_line - 1 && line[offset - 1] != '\n') {
             max_line *= 2;
             if (max_line > INI_MAX_LINE)
                 max_line = INI_MAX_LINE;
@@ -153,8 +154,6 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
             if (reader(line + offset, (int)(max_line - offset), stream) == NULL)
                 break;
             offset += strlen(line + offset);
-            if (max_line >= INI_MAX_LINE)
-                break;
         }
 #endif
 


### PR DESCRIPTION
The default is `INI_MAX_LINE == INI_INITIAL_ALLOC`:
https://github.com/benhoyt/inih/blob/f5f2c6c31e2bf5ea92d678c19c9db834f6c0f840/ini.h#L140-L142
https://github.com/benhoyt/inih/blob/f5f2c6c31e2bf5ea92d678c19c9db834f6c0f840/ini.h#L153-L155

Fixes https://github.com/benhoyt/inih/issues/200#issuecomment-3236279560.