### PR TITLE
Bug Fix: OOB Read in ini_parse_stream()

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -121,6 +121,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
     int lineno = 0;
     int error = 0;
     char abyss[16];  /* Used to consume input when a line is too long. */
+    size_t abyss_len;
 
 #if !INI_USE_STACK
     line = (char*)ini_malloc(INI_INITIAL_ALLOC);
@@ -164,7 +165,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
             while (reader(abyss, sizeof(abyss), stream) != NULL) {
                 if (!error)
                     error = lineno;
-                size_t abyss_len = strlen(abyss);
+                abyss_len = strlen(abyss);
                 if (abyss_len > 0 && abyss[abyss_len - 1] == '\n')
                     break;
             }

--- a/ini.c
+++ b/ini.c
@@ -165,7 +165,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                 if (!error)
                     error = lineno;
                 size_t abyss_len = strlen(abyss);
-                if (abyss_len > 0 && abyss[strlen(abyss) - 1] == '\n')
+                if (abyss_len > 0 && abyss[abyss_len - 1] == '\n')
                     break;
             }
         }

--- a/ini.c
+++ b/ini.c
@@ -164,7 +164,8 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
             while (reader(abyss, sizeof(abyss), stream) != NULL) {
                 if (!error)
                     error = lineno;
-                if (abyss[strlen(abyss) - 1] == '\n')
+                size_t abyss_len = strlen(abyss);
+                if (abyss_len > 0 && abyss[strlen(abyss) - 1] == '\n')
                     break;
             }
         }


### PR DESCRIPTION
Fix a stack-buffer underflow in ini_parse_stream() that was reported by AddressSanitizer. The underflow occurs when discarding the remainder of an overlong line: the code previously accessed abyss[strlen(abyss) - 1] without checking whether abyss is empty, which can produce an OOB read (abyss[-1]) and crash.

----

```
==3166400==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x73088e3001ef at pc 0x5adb89a47dd6 bp 0x7ffc1db72090 sp 0x7ffc1db72088
READ of size 1 at 0x73088e3001ef thread T0
    #0 0x5adb89a47dd5 in ini_parse_stream /root/targets/inih/fuzzing/../ini.c:167:21
    #1 0x5adb89a481b0 in ini_parse_file /root/targets/inih/fuzzing/../ini.c:268:12
    #2 0x5adb89a481b0 in ini_parse /root/targets/inih/fuzzing/../ini.c:280:13
    #3 0x5adb89a45836 in parse /root/targets/inih/fuzzing/inihfuzz.c:39:9
    #4 0x5adb89a45836 in main /root/targets/inih/fuzzing/inihfuzz.c:50:5
    #5 0x73088fe2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #6 0x73088fe2a28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #7 0x5adb899693d4 in _start (/root/targets/inih/fuzzing/inihfuzz+0x2c3d4) (BuildId: 67480adc24c6916ccc642f567748a173b3f01d16)

Address 0x73088e3001ef is located in stack of thread T0 at offset 495 in frame
    #0 0x5adb89a458ff in ini_parse_stream /root/targets/inih/fuzzing/../ini.c:99

  This frame has 4 object(s):
    [32, 232) 'line' (line 102)
    [304, 354) 'section' (line 111)
    [400, 450) 'prev_name' (line 113)
    [496, 512) 'abyss' (line 123) <== Memory access at offset 495 underflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow /root/targets/inih/fuzzing/../ini.c:167:21 in ini_parse_stream
Shadow bytes around the buggy address:
  0x73088e2fff00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x73088e2fff80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x73088e300000: f1 f1 f1 f1 00 00 00 00 00 00 00 00 00 00 00 00
  0x73088e300080: 00 00 00 00 00 00 00 00 00 00 00 00 00 f2 f2 f2
  0x73088e300100: f2 f2 f2 f2 f2 f2 00 00 00 00 00 00 02 f2 f2 f2
=>0x73088e300180: f2 f2 00 00 00 00 00 00 02 f2 f2 f2 f2[f2]00 00
  0x73088e300200: f3 f3 f3 f3 00 00 00 00 00 00 00 00 00 00 00 00
  0x73088e300280: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x73088e300300: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x73088e300380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x73088e300400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==3166400==ABORTING
```